### PR TITLE
Add Kyverno policy to disallow privileged containers

### DIFF
--- a/disallow-privileged-containers.yaml
+++ b/disallow-privileged-containers.yaml
@@ -1,0 +1,31 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  annotations:
+    policies.kyverno.io/category: "Pod Security Standards (Baseline)"
+    policies.kyverno.io/description: "Privileged mode disables most security mechanisms and must not be allowed. This policy ensures Pods do not call for privileged mode."
+    policies.kyverno.io/severity: "medium"
+    policies.kyverno.io/subject: "Pod"
+    policies.kyverno.io/title: "Disallow Privileged Containers"
+  name: disallow-privileged-containers
+spec:
+  background: true
+  rules:
+  - match:
+      any:
+      - resources:
+          kinds:
+          - Pod
+          operations:
+          - CREATE
+          - UPDATE
+    name: disallow-privileged-containers
+    validate:
+      cel:
+        expressions:
+        - expression: "variables.allContainers.all(container, container.?securityContext.?privileged.orValue(false) == false)"
+          message: "Privileged mode is disallowed. All containers must set securityContext.privileged to false or leave it unset."
+        variables:
+        - expression: "object.spec.containers + object.spec.?initContainers.orValue([]) + object.spec.?ephemeralContainers.orValue([])"
+          name: allContainers
+  validationFailureAction: Audit


### PR DESCRIPTION
This PR adds a Kyverno ClusterPolicy that prevents the creation of privileged containers in the cluster.

**Policy Details:**
- **Name:** disallow-privileged-containers
- **Category:** Pod Security Standards (Baseline)
- **Action:** Audit mode (logs violations without blocking)
- **Scope:** Applies to Pods and auto-generates rules for pod controllers (Deployments, DaemonSets, etc.)

**Security Benefits:**
- Prevents containers from running in privileged mode
- Uses CEL expressions for efficient validation
- Covers all container types (containers, initContainers, ephemeralContainers)
- Follows Kubernetes Pod Security Standards baseline requirements

The policy is initially set to Audit mode for safe deployment. It can be changed to Enforce mode after validating there are no existing privileged containers in the cluster.